### PR TITLE
Add Solar Hijri calendar and additional date range options

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {ref, onMounted} from 'vue';
-import {fetchExchangeRates, getDateRange} from './services/exchange-rates.ts';
+import {fetchExchangeRates, getDateRange, fetchExchangeRatesHijri, getDateRangeHijri} from './services/exchange-rates.ts';
 import DateRangeSelector from './components/DateRangeSelector.vue';
 import CurrencySelector from './components/CurrencySelector.vue';
 import ExchangeRateChart from './components/ExchangeRateChart.vue';
@@ -15,17 +15,20 @@ const selectedDateRange = ref<DateRange>({start: new Date(), end: new Date()});
 const loading = ref(true);
 const error = ref<string | null>(null);
 const roiEnabled = ref(false);
+const calendarType = ref('gregorian');
 
 onMounted(async () => {
   try {
-    // fetch exchange rates data
-    const data = await fetchExchangeRates();
+    let data;
+    if (calendarType.value === 'gregorian') {
+      data = await fetchExchangeRates();
+      validDataRange.value = getDateRange(data);
+    } else {
+      data = await fetchExchangeRatesHijri();
+      validDataRange.value = getDateRangeHijri(data);
+    }
     exchangeRates.value = data;
 
-    // finding the date range for the data
-    validDataRange.value = getDateRange(data);
-
-    // set date range to the last month
     const oneMonthAgo = subMonths(validDataRange.value.end, 1);
     selectedDateRange.value = {start: oneMonthAgo, end: validDataRange.value.end};
 
@@ -69,6 +72,13 @@ onMounted(async () => {
               <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer  peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
               <span class="ms-3 text-sm font-medium">ROI Mode</span>
             </label>
+          </div>
+          <div class="flex items-center space-x-4 mt-4">
+            <label for="calendarType" class="text-sm font-medium">Calendar Type:</label>
+            <select id="calendarType" v-model="calendarType" class="rounded border-gray-300">
+              <option value="gregorian">Gregorian</option>
+              <option value="hijri">Solar Hijri</option>
+            </select>
           </div>
         </div>
 

--- a/src/components/DateRangeSelector.vue
+++ b/src/components/DateRangeSelector.vue
@@ -43,6 +43,18 @@ const presetDates = ref([
     value: [subYears(props.validDateRange.end, 1), props.validDateRange.end]
   },
   {
+    label: 'Last 2 years',
+    value: [subYears(props.validDateRange.end, 2), props.validDateRange.end]
+  },
+  {
+    label: 'Last 3 years',
+    value: [subYears(props.validDateRange.end, 3), props.validDateRange.end]
+  },
+  {
+    label: 'Last 5 years',
+    value: [subYears(props.validDateRange.end, 5), props.validDateRange.end]
+  },
+  {
     label: 'All time',
     value: [props.validDateRange.start, props.validDateRange.end]
   },

--- a/src/services/exchange-rates.ts
+++ b/src/services/exchange-rates.ts
@@ -3,13 +3,27 @@ import { ExchangeRatesData } from '../types/exchange.ts';
 import {parseDate} from "../utils/utils.ts";
 
 const API_URL = 'https://raw.githubusercontent.com/SamadiPour/rial-exchange-rates-archive/refs/heads/data/gregorian_all.min.json';
+const API_URL_HIJRI = 'https://raw.githubusercontent.com/SamadiPour/rial-exchange-rates-archive/refs/heads/data/hijri_all.min.json';
 
 export async function fetchExchangeRates(): Promise<ExchangeRatesData> {
   const response = await axios.get<ExchangeRatesData>(API_URL);
   return response.data;
 }
 
+export async function fetchExchangeRatesHijri(): Promise<ExchangeRatesData> {
+  const response = await axios.get<ExchangeRatesData>(API_URL_HIJRI);
+  return response.data;
+}
+
 export function getDateRange(data: ExchangeRatesData): { start: Date; end: Date } {
+  const dates = Object.keys(data).sort();
+  return {
+    start: parseDate(dates[0]),
+    end: parseDate(dates[dates.length - 1])
+  };
+}
+
+export function getDateRangeHijri(data: ExchangeRatesData): { start: Date; end: Date } {
   const dates = Object.keys(data).sort();
   return {
     start: parseDate(dates[0]),

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import {parse} from 'date-fns';
+import {JalaliDateTime} from 'jalali-date-time';
 
 // use only for YYYY/MM/DD
 export function parseDate(input: string): Date {
@@ -20,4 +21,20 @@ export function hexToRGBA(hex: string, alpha: number): string {
     b: parseInt(hex.substring(4, 6), 16),
   };
   return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
+}
+
+export function parseDateHijri(input: string): Date {
+  const { toGregorian } = JalaliDateTime();
+  const [year, month, day] = input.split('/').map(Number);
+  const { gy, gm, gd } = toGregorian({ jy: year, jm: month, jd: day });
+  return new Date(gy, gm - 1, gd);
+}
+
+export function formatDateHijri(date: Date): string {
+  const { toJalali } = JalaliDateTime();
+  const { jy, jm, jd } = toJalali({ gy: date.getFullYear(), gm: date.getMonth() + 1, gd: date.getDate() });
+  const year = jy.toString().padStart(4, '0');
+  const month = jm.toString().padStart(2, '0');
+  const day = jd.toString().padStart(2, '0');
+  return `${year}/${month}/${day}`;
 }


### PR DESCRIPTION
Add Solar Hijri calendar support and new date range options.

* Add options for "Last 2 years", "Last 3 years", and "Last 5 years" to `presetDates` in `src/components/DateRangeSelector.vue`.
* Add `fetchExchangeRatesHijri` and `getDateRangeHijri` functions in `src/services/exchange-rates.ts` to fetch and handle Solar Hijri calendar data.
* Add `parseDateHijri` and `formatDateHijri` functions in `src/utils/utils.ts` to parse and format Solar Hijri dates.
* Update `src/App.vue` to include a dropdown for selecting the calendar type (Gregorian or Solar Hijri) and fetch data accordingly.

