### PR TITLE
Add Jalali calendar support

### DIFF
--- a/src/components/DateRangeSelector.vue
+++ b/src/components/DateRangeSelector.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import {onMounted, ref} from 'vue';
+import {onMounted, ref, watch} from 'vue';
 import {subDays, subMonths, subYears} from 'date-fns';
 import {DateRange} from "../types/exchange.ts";
 import VueDatePicker from '@vuepic/vue-datepicker';
-import {formatDate} from "../utils/utils.ts";
+import {formatDate, formatDateHijri} from "../utils/utils.ts";
 
 const emit = defineEmits(['update:dateRange']);
 const props = defineProps({
@@ -14,6 +14,10 @@ const props = defineProps({
   selectedDateRange: {
     type: Object as () => DateRange,
     default: null,
+  },
+  calendarType: {
+    type: String,
+    required: true,
   },
 });
 
@@ -61,7 +65,7 @@ const presetDates = ref([
 ]);
 
 const dateRange = ref<[Date, Date]>([new Date(), new Date()]);
-const formatDateOutput = (date: Date[]) => date.map(formatDate).join(' - ');
+const formatDateOutput = (date: Date[]) => date.map(d => props.calendarType === 'gregorian' ? formatDate(d) : formatDateHijri(d)).join(' - ');
 
 function applyDateRange() {
   if (dateRange.value[0] && dateRange.value[1]) {
@@ -76,6 +80,51 @@ onMounted(() => {
   if (props.selectedDateRange) {
     dateRange.value = [props.selectedDateRange.start, props.selectedDateRange.end];
   }
+});
+
+watch(() => props.calendarType, () => {
+  presetDates.value = [
+    {
+      label: 'Last 7 days',
+      value: [subDays(props.validDateRange.end, 7), props.validDateRange.end]
+    },
+    {
+      label: 'Last 14 days',
+      value: [subDays(props.validDateRange.end, 14), props.validDateRange.end]
+    },
+    {
+      label: 'Last 30 days',
+      value: [subDays(props.validDateRange.end, 30), props.validDateRange.end]
+    },
+    {
+      label: 'Last 3 months',
+      value: [subMonths(props.validDateRange.end, 3), props.validDateRange.end]
+    },
+    {
+      label: 'Last 6 months',
+      value: [subMonths(props.validDateRange.end, 6), props.validDateRange.end]
+    },
+    {
+      label: 'Last year',
+      value: [subYears(props.validDateRange.end, 1), props.validDateRange.end]
+    },
+    {
+      label: 'Last 2 years',
+      value: [subYears(props.validDateRange.end, 2), props.validDateRange.end]
+    },
+    {
+      label: 'Last 3 years',
+      value: [subYears(props.validDateRange.end, 3), props.validDateRange.end]
+    },
+    {
+      label: 'Last 5 years',
+      value: [subYears(props.validDateRange.end, 5), props.validDateRange.end]
+    },
+    {
+      label: 'All time',
+      value: [props.validDateRange.start, props.validDateRange.end]
+    },
+  ];
 });
 </script>
 

--- a/src/components/ExchangeRateChart.vue
+++ b/src/components/ExchangeRateChart.vue
@@ -15,7 +15,7 @@ import {
 } from 'chart.js';
 import {DateRange, ExchangeRatesData} from '../types/exchange';
 import {CURRENCIES} from '../constants/currencies';
-import {hexToRGBA} from "../utils/utils.ts";
+import {hexToRGBA, parseDate, parseDateHijri} from "../utils/utils.ts";
 import {verticalHoverLine} from "../utils/chart-plugins.ts";
 import 'chartjs-adapter-date-fns';
 
@@ -37,11 +37,15 @@ const props = defineProps<{
   selectedCurrencies: string[];
   dateRange: DateRange;
   roiEnabled: boolean;
+  calendarType: string;
 }>();
 
 const filteredDates = computed(() => {
   return Object.entries(props.data)
-      .map(([key, _]) => ({key, date: new Date(key)}))
+      .map(([key, _]) => ({
+        key,
+        date: props.calendarType === 'gregorian' ? parseDate(key) : parseDateHijri(key)
+      }))
       .filter(({date}) => {
         return date >= props.dateRange.start && date <= props.dateRange.end;
       });

--- a/src/services/exchange-rates.ts
+++ b/src/services/exchange-rates.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { ExchangeRatesData } from '../types/exchange.ts';
-import {parseDate} from "../utils/utils.ts";
+import {parseDate, parseDateHijri} from "../utils/utils.ts";
 
 const API_URL = 'https://raw.githubusercontent.com/SamadiPour/rial-exchange-rates-archive/refs/heads/data/gregorian_all.min.json';
 const API_URL_HIJRI = 'https://raw.githubusercontent.com/SamadiPour/rial-exchange-rates-archive/refs/heads/data/hijri_all.min.json';
@@ -26,7 +26,7 @@ export function getDateRange(data: ExchangeRatesData): { start: Date; end: Date 
 export function getDateRangeHijri(data: ExchangeRatesData): { start: Date; end: Date } {
   const dates = Object.keys(data).sort();
   return {
-    start: parseDate(dates[0]),
-    end: parseDate(dates[dates.length - 1])
+    start: parseDateHijri(dates[0]),
+    end: parseDateHijri(dates[dates.length - 1])
   };
 }


### PR DESCRIPTION
Add support for using the Jalali calendar alongside the Gregorian calendar.

* **src/services/exchange-rates.ts**
  - Import `parseDateHijri` function.
  - Update `getDateRangeHijri` function to use `parseDateHijri`.

* **src/components/DateRangeSelector.vue**
  - Import `watch` and `formatDateHijri` functions.
  - Add `calendarType` prop.
  - Update `formatDateOutput` function to use `formatDateHijri` based on `calendarType`.
  - Add `watch` function to update `presetDates` based on `calendarType`.

* **src/components/ExchangeRateChart.vue**
  - Import `parseDate` and `parseDateHijri` functions.
  - Add `calendarType` prop.
  - Update `filteredDates` computed property to use `parseDateHijri` based on `calendarType`.

