### PR TITLE
Fix white screen issue in Rial Exchange Rates Archive

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@ import ExchangeRateChart from './components/ExchangeRateChart.vue';
 import type {DateRange, ExchangeRatesData} from './types/exchange';
 import {LineChart} from 'lucide-vue-next';
 import {subMonths} from "date-fns";
+import { useHead } from '@vueuse/head';
 
 const exchangeRates = ref<ExchangeRatesData>({});
 const validDataRange = ref<DateRange>({start: new Date(), end: new Date()});
@@ -37,6 +38,10 @@ onMounted(async () => {
     error.value = 'Failed to load exchange rates data';
     loading.value = false;
   }
+
+  useHead({
+    title: 'Rial Exchange Rates Archive'
+  });
 });
 
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,12 @@ import './index.css'
 import App from './App.vue'
 import VueDatePicker from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css'
+import { createHead } from '@vueuse/head';
 
 const app = createApp(App);
 app.component('VueDatePicker', VueDatePicker);
+
+const head = createHead();
+app.use(head);
+
 app.mount('#app');


### PR DESCRIPTION
Add page title management using `@vueuse/head` to display content correctly.

* **src/App.vue**
  - Import `useHead` from `@vueuse/head`.
  - Add `useHead` call in `onMounted` to set the page title to "Rial Exchange Rates Archive".

* **src/main.ts**
  - Import `createHead` from `@vueuse/head`.
  - Create a `head` instance using `createHead` and use it in the app.

